### PR TITLE
Small change to `Icon`

### DIFF
--- a/src/ui/panels/top_bar.rs
+++ b/src/ui/panels/top_bar.rs
@@ -7,7 +7,7 @@ pub fn top_bar(cx: &mut Context) {
         Button::new(
             cx,
             |cx| cx.emit(PanelEvent::TogglePianoRoll),
-            |cx| Icon::new(cx, IconCode::Piano, 24.0),
+            |cx| Icon::new(cx, IconCode::Piano, 24.0, 16.0),
         )
         .left(Stretch(1.0))
         .right(Pixels(20.0));

--- a/src/ui/views/icon.rs
+++ b/src/ui/views/icon.rs
@@ -5,17 +5,28 @@ use crate::ui::icons::IconCode;
 pub struct Icon {}
 
 impl Icon {
-    pub fn new<'a>(cx: &'a mut Context, icon: IconCode, size: f32) -> Handle<'a, Self> {
+    // Creates an Icon with a set size for the outer frame and the icon.
+    pub fn new<'a>(cx: &'a mut Context, icon: IconCode, frame_size: f32, icon_size: f32) -> Handle<'a, Self> {
         Self {}.build2(cx, |cx| {
             let icon_str: &str = icon.into();
 
+            // Icon can't be bigger than the frame it's held in.
+            if icon_size > frame_size {
+                icon_size = frame_size;
+            }
+
             Label::new(cx, icon_str)
-                .width(Pixels(size))
-                .height(Pixels(size))
-                .font_size(size * 0.666)
+                .width(Pixels(frame_size))
+                .height(Pixels(frame_size))
+                .font_size(icon_size)
                 .font("meadowlark")
                 .class("icon");
         })
+    }
+
+    // Creates an Icon with a frame of `24px` and an icon of `16px`.
+    pub fn default<'a>(cx: &'a mut Context, icon: IconCode) -> Handle<'a, Self> {
+        Self::new(cx, icon, 24.0, 16.0)
     }
 }
 

--- a/src/ui/views/icon.rs
+++ b/src/ui/views/icon.rs
@@ -10,15 +10,17 @@ impl Icon {
         Self {}.build2(cx, |cx| {
             let icon_str: &str = icon.into();
 
+            let mut icon_sz = icon_size;
+
             // Icon can't be bigger than the frame it's held in.
             if icon_size > frame_size {
-                icon_size = frame_size;
+                icon_sz = frame_size;
             }
 
             Label::new(cx, icon_str)
                 .width(Pixels(frame_size))
                 .height(Pixels(frame_size))
-                .font_size(icon_size)
+                .font_size(icon_sz)
                 .font("meadowlark")
                 .class("icon");
         })

--- a/src/ui/views/icon.rs
+++ b/src/ui/views/icon.rs
@@ -23,7 +23,12 @@ impl Icon {
                 .font_size(icon_sz)
                 .font("meadowlark")
                 .class("icon");
-        })
+        }).size(Auto)
+    }
+
+    // Creates an Icon with a frame of `24px` and an icon of `16px`.
+    pub fn default<'a>(cx: &'a mut Context, icon: IconCode) -> Handle<'a, Self> {
+        Self::new(cx, icon, 24.0, 16.0)
     }
 
     // Creates an Icon with a frame of `24px` and an icon of `16px`.

--- a/src/ui/views/icon.rs
+++ b/src/ui/views/icon.rs
@@ -31,10 +31,6 @@ impl Icon {
         Self::new(cx, icon, 24.0, 16.0)
     }
 
-    // Creates an Icon with a frame of `24px` and an icon of `16px`.
-    pub fn default<'a>(cx: &'a mut Context, icon: IconCode) -> Handle<'a, Self> {
-        Self::new(cx, icon, 24.0, 16.0)
-    }
 }
 
 impl View for Icon {


### PR DESCRIPTION
After playing around with other views and trying to copy the mock-up using the `Icon` view, I realized that some icons don't maintain a constant size based on the frame it's held in. E.g: Given a frame of size `x` px, the icon is always `x * 0.66` px.

This changes makes sure you can create any icon with the framing and icon size that you want.

I also added a small other function just so you can quickly create an icon with the default size that the mock-up uses.