### PR TITLE
Bump `simple-logger` to 2.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,4 +32,4 @@ smallvec = "1.6"
 num-traits = "0.2"
 symphonia = { version = "0.3", features = ["mp3", "aac", "isomp4"] }
 log = "0.4"
-simple_logger = "1.11"
+simple_logger = "2.1"


### PR DESCRIPTION
First of all thanks for this project, looks pretty cool already, super excited to see a DAW written in Rust make progress.

Running it on arm64 (M1) macOS currently crashes with the message:

```
thread 'main' panicked at 'Could not determine the UTC offset on this system. Possible causes are that the time crate does not implement "local_offset_at" on your system, or that you are running in a multi-threaded environment and the time crate is returning "None" from "local_offset_at" to avoid unsafe behaviour. See the time crate's documentation for more information. (https://time-rs.github.io/internal-api/time/index.html#feature-flags): IndeterminateOffset', /Users/<user>/.cargo/registry/src/github.com-1ecc6299db9ec823/simple_logger-1.16.0/src/lib.rs:409:85
```

Other apps have encountered the [same issue](https://github.com/martinber/noaa-apt/issues/42) and while local time doesn't seem to really work yet, `simple-logger` 2.0 defaults to UTC time as a fallback instead of crashing, thereby fixing the issue for now.