### PR TITLE
Update clip.rs - Rename "SuperFrames"

### DIFF
--- a/src/program_layer/program_state/clip.rs
+++ b/src/program_layer/program_state/clip.rs
@@ -1,4 +1,4 @@
-use meadowlark_core_types::{MusicalTime, Seconds, SuperFrames};
+use meadowlark_core_types::{MusicalTime, Seconds, SuperFrame};
 use vizia::prelude::*;
 
 #[derive(Debug, Lens, Clone, Data, Serialize, Deserialize)]
@@ -17,7 +17,7 @@ pub struct AudioClipState {
     /// and the start of the clip.
     ///
     /// TODO
-    pub clip_start_offset: SuperFrames,
+    pub clip_start_offset: SuperFrame,
     // TODO: pointer to waveform data
 }
 


### PR DESCRIPTION
In clip.rs, there's an import called "SuperFrames" and this causes a compiler error, because "SuperFrames" is actually "SuperFrame".
I have renamed the two instances of SuperFrame in clip.rs, and the dev branch should now compile.

This is my first PR. 😳
I hope I did this right.