### PR TITLE
change isize to usize to prevent type errors

### DIFF
--- a/src/backend/sample_browser_plug.rs
+++ b/src/backend/sample_browser_plug.rs
@@ -333,7 +333,7 @@ impl PluginAudioThread for SampleBrowserPlugAudioThread {
             let pcm = self.pcm.as_ref().unwrap();
 
             if playhead < pcm.len_frames() as usize {
-                pcm.fill_stereo_f32(playhead as isize, buf_l_part, buf_r_part);
+                pcm.fill_stereo_f32(playhead as usize, buf_l_part, buf_r_part);
 
                 playhead += proc_info.frames;
 
@@ -366,7 +366,7 @@ impl PluginAudioThread for SampleBrowserPlugAudioThread {
 
             if old_playhead < old_pcm.len_frames() as usize {
                 old_pcm.fill_stereo_f32(
-                    old_playhead as isize,
+                    old_playhead as usize,
                     declick_buf_l_part,
                     declick_buf_r_part,
                 );


### PR DESCRIPTION
"isize" might be a typo. I changed those to "usize" to fix any possible type mismatch errors.